### PR TITLE
CentOS minimal installs may not include libaio, which is required for XE...

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,7 @@ end
 
 # Pre-req for Oracle %preinstall scriptlet
 package 'bc'
+package 'libaio'
 
 yum_package 'oracle-xe' do
   source File.join(Chef::Config[:file_cache_path], 'oracle-xe-11.2.0-1.0.x86_64.rpm')


### PR DESCRIPTION
Cookbook fails against a CentOS 6.5 minimal install -- database will not start (attempts result in an ORA-600), but no error is generated. Older installation instructions for Oracle XE reference the packages bc, libaio and flex. Adding libaio resolves the database start error -- so far no need for the flex package.

Reference:
http://warp11.nl/2011/07/update-oracle-xe-11g-r2-on-centos-6/
