### PR TITLE
added ability to use yum

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Include the default recipe in your run list after setting the URL attribute.
 # Attributes
 
 * `node['oracle-xe']['url']` - The URL where you've placed the Oracle 11g Express Edition RPM.
+* `node['oracle-xe']['urldownload']` - Boolean whether to use url to download or use package resource (does not create a yum repo config file)
 * `node['oracle-xe']['http-port']` - The port where you want the HTTP interface to be listening.
 * `node['oracle-xe']['tnslsnr-port']` - The port where you want the TNS listener to be listening.
 * `node['oracle-xe']['oracle-password']`  - The password for the SYS and SYSTEM accounts.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@
 # Put the Oracle XE RPM somewhere and list its URL in this attribute. Typically you'll want
 # to do this from within a role
 default['oracle-xe']['url'] = nil
+default['oracle-xe']['urldownload'] = true
 
 default['oracle-xe']['http-port'] = 8079
 default['oracle-xe']['tnslsnr-port'] = 1521

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,18 +18,22 @@
 # limitations under the License.
 #
 
-remote_file File.join(Chef::Config[:file_cache_path], 'oracle-xe-11.2.0-1.0.x86_64.rpm') do
-  source node['oracle-xe']['url']
-  action :create
-end
-
 # Pre-req for Oracle %preinstall scriptlet
 package 'bc'
 package 'libaio'
 
-yum_package 'oracle-xe' do
-  source File.join(Chef::Config[:file_cache_path], 'oracle-xe-11.2.0-1.0.x86_64.rpm')
-  action :install
+if node['oracle-xe']['urldownload']
+  remote_file File.join(Chef::Config[:file_cache_path], 'oracle-xe-11.2.0-1.0.x86_64.rpm') do
+    source node['oracle-xe']['url']
+    action :create
+  end
+
+  yum_package 'oracle-xe' do
+    source File.join(Chef::Config[:file_cache_path], 'oracle-xe-11.2.0-1.0.x86_64.rpm')
+    action :install
+  end
+else
+  package 'oracle-xe'
 end
 
 rspfile = File.join(Chef::Config[:file_cache_path], 'xe.rsp')


### PR DESCRIPTION
We have custom yum repositories to store all rpms so that we never have to go out to internet to download directly.  added boolean option to turn off url download and use the package resource as normal to download and install through package manager.  Note that this does not configure any yum repository configurations or repositories but simply skips url download and just does a package install